### PR TITLE
Fixing a few warnings, MKMapAnnotation changed slightly so the title property needed a change, now shows no warnings in Xcode 4.2

### DIFF
--- a/Classes/UICRouteAnnotation.h
+++ b/Classes/UICRouteAnnotation.h
@@ -22,7 +22,7 @@ typedef enum UICRouteAnnotationType {
 }
 
 @property (nonatomic) CLLocationCoordinate2D coordinate;
-@property (nonatomic, retain) NSString *title;
+@property (nonatomic, readonly, copy) NSString *title;
 @property (nonatomic) UICRouteAnnotationType annotationType;
 
 - (id)initWithCoordinate:(CLLocationCoordinate2D)coord 

--- a/MapDirections.xcodeproj/project.pbxproj
+++ b/MapDirections.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -287,8 +287,11 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0420;
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MapDirections" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -394,7 +397,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
-				PREBINDING = NO;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 			};
@@ -410,7 +412,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 3.0;
-				PREBINDING = NO;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 				SDKROOT = iphoneos;
 			};


### PR DESCRIPTION
...ed warning in UICRouteAnnotation for title property per Apple Docs
