### PR TITLE
Walking travel mode fixed

### DIFF
--- a/Classes/UICGRoute.m
+++ b/Classes/UICGRoute.m
@@ -30,8 +30,14 @@
 	self = [super init];
 	if (self != nil) {
 		dictionaryRepresentation = [dictionary retain];
-        NSArray *allKeys = [dictionaryRepresentation allKeys];
-        NSDictionary *k = [dictionaryRepresentation objectForKey:[allKeys objectAtIndex:[allKeys count] - 1]];
+        NSDictionary *k;
+        for(NSString *key in [dictionaryRepresentation allKeys]){
+            if ([[dictionaryRepresentation objectForKey:key] isKindOfClass:[NSDictionary class]] &&
+                [[dictionaryRepresentation objectForKey:key] objectForKey:@"Steps"]) {
+                k = [dictionaryRepresentation objectForKey:key];
+            }
+        }
+        NSLog(@"K %@", k);
 		NSArray *stepDics = [k objectForKey:@"Steps"];
 		numerOfSteps = [stepDics count];
 		steps = [[NSMutableArray alloc] initWithCapacity:numerOfSteps];

--- a/api.html
+++ b/api.html
@@ -13,7 +13,7 @@
 
 	function initialize() {
 		if (GBrowserIsCompatible()) {
-			gdir = new GDirections(null, null);
+			gdir = new GDirections(null, "body");
 			geocoder = new GClientGeocoder();
 			
 			GEvent.addListener(gdir, "load", onGDirectionsLoad);


### PR DESCRIPTION
Setting the travel mode to UICGTravelModeWalking was causing the following error to be thrown

> Error Domain=org.brautaset.JSON.ErrorDomain Code=3 \"Unrecognised leading character (41)\

The bug was caused by a wrong use of _GDirections_. As stated in the google maps API documentation

> The mode of travel, such as driving (default) or walking. Note that if you specify walking directions, you will need to specify a panel to hold a warning notice to users.

then 

``` javascript
gdir = new GDirections(null, null);
```

has been replaced with this

``` javascript
gdir = new GDirections(null, "body");
```
